### PR TITLE
There used to be a seg fault after finishing the final level, level 1…

### DIFF
--- a/src/LevelSelect.cpp
+++ b/src/LevelSelect.cpp
@@ -14,7 +14,9 @@ LevelSelect::LevelSelect(){}
 * @param orb: orb to append
 */
 void LevelSelect::appendDot(SelectOrb orb){
-  this -> levels.push_back(orb);
+	if(this -> levels.size() < 12){
+  		this -> levels.push_back(orb);
+  	}
 }
 
 /*


### PR DESCRIPTION
There used to be a set fault after the final level, level 12. This is because the game tried to draw a 13th level selection dot in the title screen when the xml only holds 12. I placed an if statement to only allow drawing level selector dots for levels 1-12. Stopping the game from trying to draw anything extra after beating the game.